### PR TITLE
Fix u-boot environment for arria10-socdk

### DIFF
--- a/recipes-bsp/u-boot/env/arria10-socdk_u-boot-env.txt
+++ b/recipes-bsp/u-boot/env/arria10-socdk_u-boot-env.txt
@@ -9,7 +9,7 @@ bootcmd_dhcp=setenv devtype dhcp; run boot_net_usb_start; if dhcp ${scriptaddr} 
 bootcmd_mmc0=devnum=0; run mmc_boot
 bootcmd_pxe=run boot_net_usb_start; dhcp; if pxe get; then pxe boot; fi
 bootcmd_qspi=run qspiload; run qspiboot
-bootdelay=2
+bootdelay=5
 boot_efi_binary=load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} efi/boot/bootarm.efi; if fdt addr ${fdt_addr_r}; then bootefi ${kernel_addr_r} ${fdt_addr_r};else bootefi ${kernel_addr_r} ${fdtcontroladdr};fi
 boot_efi_bootmgr=if fdt addr ${fdt_addr_r}; then bootefi bootmgr ${fdt_addr_r};else bootefi bootmgr;fi
 boot_extlinux=sysboot ${devtype} ${devnum}:${distro_bootpart} any ${scriptaddr} ${prefix}${boot_syslinux_conf}


### PR DESCRIPTION
Related to #2

Update the `bootdelay` variable in `arria10-socdk_u-boot-env.txt` to 5.

